### PR TITLE
fix npm start crash by removing extra bracket

### DIFF
--- a/src/components/Queue/QueueContainer.css
+++ b/src/components/Queue/QueueContainer.css
@@ -69,8 +69,6 @@ body {
 }
 
 
-}
-
 .statusMenu > button {
 	border: none;
 	margin: 0;


### PR DESCRIPTION
Related to:
https://github.com/codefordenver/ideaLab/pull/77

I just realized that was something we resolved the conflicts for, but I guess it got added in or let in somehow and broke it, hence it working on my machine and not master / the pr branch. 