### PR TITLE
Renamed /audits/printjobs

### DIFF
--- a/Backend/src/main/java/idealab/api/controller/AuditController.java
+++ b/Backend/src/main/java/idealab/api/controller/AuditController.java
@@ -20,7 +20,7 @@ public class AuditController {
         return new ResponseEntity<>(response, response.getHttpStatus());
     }
 
-    @GetMapping("/printjobs/{print-id}")
+    @GetMapping("/print-jobs/{print-id}")
     public ResponseEntity<?> getPrintJobAuditTableGetById(@PathVariable("print-id") Integer printId) {
         PrintJobAuditResponse response = auditOperations.printJobAuditById(printId);
         return new ResponseEntity<>(response, response.getHttpStatus());

--- a/Backend/src/main/java/idealab/api/controller/AuditController.java
+++ b/Backend/src/main/java/idealab/api/controller/AuditController.java
@@ -14,7 +14,7 @@ public class AuditController {
         this.auditOperations = auditOperations;
     }
 
-    @GetMapping("/printjobs")
+    @GetMapping("/print-jobs")
     public ResponseEntity<?> getAllPrintJobsAuditTable() {
         PrintJobAuditResponse response = auditOperations.allPrintJobsAudit();
         return new ResponseEntity<>(response, response.getHttpStatus());

--- a/Backend/src/test/java/idealab/api/controller/AuditControllerTest.java
+++ b/Backend/src/test/java/idealab/api/controller/AuditControllerTest.java
@@ -44,7 +44,7 @@ public class AuditControllerTest {
 
     @Test
     public void getAllPrintJobsAuditSuccess() throws Exception {
-        String uri = "/api/audit/printjobs";
+        String uri = "/api/audit/print-jobs";
         // given
         PrintJobAuditModel auditModel = new PrintJobAuditModel();
         auditModel.setId(2);
@@ -75,7 +75,7 @@ public class AuditControllerTest {
 
     @Test
     public void getPrintJobsAuditByIdSuccess() throws Exception {
-        String uri = "/api/audit/printjobs/3";
+        String uri = "/api/audit/print-jobs/3";
         // given
         PrintJobAuditModel auditModel = new PrintJobAuditModel();
         auditModel.setId(3);


### PR DESCRIPTION
Changing the endpoint ```/api/audits/printjobs``` to ```/api/audits/print-jobs``` for consistency with ```/api/print-jobs```. 