### PR TITLE
Added an interval to the queuing page

### DIFF
--- a/Frontend/src/components/Queue/QueueContainer.jsx
+++ b/Frontend/src/components/Queue/QueueContainer.jsx
@@ -18,6 +18,23 @@ const QueueContainer = () => {
     setLoading(false);
   }, []);
 
+  useEffect(() => {
+    //Load initial data and set the loading only on first load
+    setLoading(true);
+    fetchQueueData();
+    setLoading(false);
+
+    //Sets an interval to re-fetch data on an interval.
+    const interval = setInterval(() => {
+      fetchQueueData();
+
+      //Time is in milliseconds (1000*60*5 = 5 mins)
+    }, 1000 * 60 * 5);
+
+    //Clean up function should remove the interval on the component unmount
+    return () => clearInterval(interval);
+  }, [statusView]);
+
   const returnCardStatus = cardStatus => {
     const failedStatuses = ['FAILED', 'REJECTED', 'COMPLETED', 'ARCHIVED'];
     const waitingStatuses = ['PENDING_CUSTOMER_RESPONSE', 'PENDING_REVIEW'];
@@ -45,8 +62,7 @@ const QueueContainer = () => {
     RequestService.saveCard(updatedCard, onSaveCardSuccess, onFailure);
   };
 
-  useEffect(() => {
-    setLoading(true);
+  const fetchQueueData = () => {
     //TO DO: GET PRINT JOBS BASED ON STATUS, NOT ALL AT ONCE
     RequestService.getPrintJobs(
       response => {
@@ -66,11 +82,10 @@ const QueueContainer = () => {
           }
         });
         setFilteredData(activeCards);
-        setLoading(false);
       },
       error => console.error(error),
     );
-  }, [statusView]);
+  };
 
   const setStatus = view => {
     setStatusView(view);

--- a/Frontend/src/util/ColorUtils.js
+++ b/Frontend/src/util/ColorUtils.js
@@ -5,7 +5,6 @@ const processActiveColors = () => {
 
   RequestService.getActiveColors(
     response => {
-      console.log(response);
       const data = response.data.data;
       data.map(color => {
         colorList.push(color.color);


### PR DESCRIPTION
Closes #178 

This adds a basic interval for refreshing the data every 5 minutes when on the queue page.

Because the cards are rendered by ID, I believe no data is lost on the polling as react knows the data is not changed on the card component.  I tested this by both adding a new print job and using two windows to move print jobs from the printing back to the queue page and any unsaved changes remained.