### PR TITLE
Updated card overflows so the save button is always visible

### DIFF
--- a/Frontend/src/components/Queue/components/PrintCardContainer.css
+++ b/Frontend/src/components/Queue/components/PrintCardContainer.css
@@ -6,6 +6,7 @@
   text-align: left;
   width: 97%;
   height: fit-content;
+  overflow: visible;
 }
 
 .mouseOverColorPickerContainer {
@@ -66,7 +67,6 @@
 
 .printAdditionalInfo {
   display: flex;
-  overflow: overlay;
 }
 
 .emailRecipient {


### PR DESCRIPTION
This is part of #327 and fixes the save icon being properly shown.